### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/ykaliuta/dictem.git -b packaging
 
 Package: dictem
 Architecture: all
-Depends: ${misc:Depends}, dict (>> 1.9.14), emacsen-common (>= 2.0.0)
+Depends: ${misc:Depends}, dict, emacsen-common
 Conflicts: emacsen-common (< 2.0.0)
 Provides: dict-client
 Description: Dict client for emacs


### PR DESCRIPTION
Remove unnecessary constraints.

## Debdiff

These changes affect the binary packages:

File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Depends: [-dict (>> 1.9.14),-] {+dict,+} emacsen-common [-(>= 2.0.0)-]

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/7b5580f1-4edf-4cd3-80b3-6c73c7fffff9/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/7b5580f1-4edf-4cd3-80b3-6c73c7fffff9/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/scrub-obsolete), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/dictem/7b5580f1-4edf-4cd3-80b3-6c73c7fffff9.